### PR TITLE
Update dependencies

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,5 @@
-var Q = require('qq'),
-    QFS = require('q-fs'),
+var Q = require('q'),
+    QFS = require('q-io/fs'),
     CP = require('child_process'),
     FS = require('fs'),
     PATH = require('path'),
@@ -76,16 +76,8 @@ exports.main = function () {
         .completable()
         .act(function(opts, args) {
 
-            return Q.step(
-                function() {
-
-                    return loadConf({
-                        'cache': PATH.resolve('.cache')
-                    });
-
-                },
-                function() {
-
+            return loadConf({cache: PATH.resolve('.cache')})
+                .then(function() {
                     console.log('versioned = %s', opts.versioned);
                     console.log('bin = %s', NPM.bin);
                     console.log('dir = %s', NPM.dir);
@@ -96,11 +88,9 @@ exports.main = function () {
                     return args.pkg.reduce(function(done, pkg) {
                         return Q.all([done, debianize(pkg, opts)]).get(0);
                     }, undefined);
+                });
 
-                }
-            );
-
-        }) 
+        })
         .run();
 
 };
@@ -142,14 +132,10 @@ var cacheUnpack = function(pkg, ver, targetPath) {
 
 var debianize = function(pkg, opts) {
     console.log('debianize: %s', pkg);
-    return Q.step(
-        function() {
-            return cacheAdd(pkg);
-        },
-        function(data) {
+    return cacheAdd(pkg)
+        .then(function(data) {
             return makeSourcePackage(data.name, data.version, opts);
-        }
-    );
+        });
 };
 
 var makeSourcePackage = function(pkg, ver, opts) {
@@ -172,23 +158,19 @@ var makeSourcePackage = function(pkg, ver, opts) {
     var debianPackageDir = PATH.join(opts.output, ctx.debianName + '-' + ver),
         debianDir = PATH.join(debianPackageDir, 'debian');
 
-    return Q.step(
-        function() {
-            return QFS.exists(debianPackageDir);
-        },
-        function(exists) {
-            var steps = [];
-            if(exists) steps.push(function() {
+    return QFS.exists(debianPackageDir)
+        .then(function(exists) {
+            if (exists) {
                 return rimraf(debianPackageDir);
-            });
-            steps.push(
-                function() {
-                    return cacheUnpack(pkg, ver, debianPackageDir);
-                },
-                function() {
+            }
+        })
+        .then(function() {
+
+            return cacheUnpack(pkg, ver, debianPackageDir)
+                .then(function() {
                     return cacheRead(pkg, ver);
-                },
-                function(packageData) {
+                })
+                .then(function(packageData) {
 
                     ctx.packageData = packageData;
                     ctx.shortdesc = packageData.description || '';
@@ -221,25 +203,22 @@ var makeSourcePackage = function(pkg, ver, opts) {
                     ctx.depends = semverToDebian('nodejs', nodeVer);
                     ctx.buildDepends = semverToDebian('npm', npmVer);
 
-                },
-                function() {
+                })
+                .then(function() {
                     return dh_make(debianPackageDir, ctx);
-                },
-                function() {
+                })
+                .then(function() {
                     return dch(debianPackageDir, ctx.debianName, ctx.debianVersion, 'Release of ' + pkg + ' ' + ver);
-                },
-                function() {
+                })
+                .then(function() {
                     return Q.all([
                         tplDebianFile(PATH.join(debianDir, 'control'), ctx),
                         tplDebianFile(PATH.join(debianDir, 'rules'), ctx),
                         tplDebianFile(PATH.join(debianDir, 'links'), ctx)
                     ]);
-                }
-            );
-            return Q.step.apply(null, steps);
-        }
-    );
+                });
 
+        });
 };
 
 var filterObjectKeys = function(obj, cb) {
@@ -324,18 +303,18 @@ var parseTemplate = function(template, vars) {
         });
 };
 
-var parseRange = function(range) {
-    return SEMVER.toComparators(SEMVER.replaceStars(range.trim()));
-};
-
 var semverToDebian = function(pkg, ver) {
     if(!ver) return pkg;
 
-    var ranges = parseRange(ver),
+    var comparators = SEMVER.Range(ver, true).set,
         deps = [];
 
-    ranges.forEach(function(range) {
-        range.forEach(function(edge) {
+    comparators.forEach(function(comp) {
+
+        comp.forEach(function(edge) {
+            // strip leading "-0"
+            edge = edge.value.replace(/-0$/, '');
+
             if(!edge) {
                 deps.push(pkg);
             } else {

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "npm2debian": "./bin/npm2debian"
   },
   "dependencies": {
-    "coa": "0.3",
-    "npm": "1.0",
-    "qq": "0.3",
-    "q-fs": "0.1",
-    "rimraf": "1",
-    "semver": "~1.0.13"
+    "coa": "~0.4.0",
+    "npm": "~1.3.15",
+    "rimraf": "~2.2.2",
+    "semver": "~2.2.1",
+    "q": "~0.9.7",
+    "q-io": "~1.10.6"
   },
   "engines": {
-    "node": ">=0.4.0 <=0.7.0"
+    "node": ">=0.8.0 <=0.11.0"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
- switch `q-fs` to `q-io ~1.10.6`
- switch `qq` to `q ~0.9.7`
- update `semver` to `~2.2.1`
- update `coa` to `~0.4.0`
- update `npm` to `~1.3.15`
- update `rimraf` to `~2.2.2`
- fix code to use updated deps
